### PR TITLE
$pages->visible() is deprecated. Using $pages->listed() instead

### DIFF
--- a/src/feeds.php
+++ b/src/feeds.php
@@ -529,7 +529,7 @@ class Feeds
   * @SuppressWarnings(PHPMD.NPathComplexity)
    */
   private static function addPagesToFeedWhatever( Pages $pages, string &$r, callable $runner, int &$lastMod ) : void {
-    $sortedpages = $pages->visible()->sortBy( 'date', 'asc' )->flip()->limit( 60 );
+    $sortedpages = $pages->listed()->sortBy( 'date', 'asc' )->flip()->limit( 60 );
 
     $numPage = $sortedpages->count();
 


### PR DESCRIPTION
Update to keep compatible with future Kirby releases as stated in this issue:
#8 